### PR TITLE
Fix - iOS: Replace non URL characters in asset paths

### DIFF
--- a/ios/Plugin/AudioAsset.swift
+++ b/ios/Plugin/AudioAsset.swift
@@ -28,7 +28,7 @@ public class AudioAsset: NSObject, AVAudioPlayerDelegate {
 
         super.init()
 
-        let pathUrl: URL = URL(string: path)!
+        let pathUrl: URL = URL(string: path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)!
         for _ in 0..<channels {
             do {
                 let player: AVAudioPlayer! = try AVAudioPlayer(contentsOf: pathUrl)


### PR DESCRIPTION
If the path contains invalid url characters, this fixes the path before creating the url.

Closes #27